### PR TITLE
feat(projects): data-driven grid + preview en Home (featured)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
+// src/app/page.tsx
 import Hero from "@/components/Hero";
+import { ProjectsPreview } from "@/components/projects/ProjectsPreview";
 
 export default function Home() {
   return (
@@ -15,6 +17,9 @@ export default function Home() {
           RAG con guardarraíl, demo en vivo y proyectos seleccionados.
         </p>
       </section>
+
+      {/* Proyectos destacados (featured) */}
+      <ProjectsPreview />
     </main>
   );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,21 +1,22 @@
+// src/app/projects/page.tsx
 export const metadata = {
   title: "Proyectos",
   description: "Selección de proyectos y casos con IA aplicada.",
 };
 
-import { Card } from "@/components/ui/card"
+import { projects } from "@/data/projects";
+import { ProjectCard } from "@/components/projects/ProjectCard";
 
-export default function Projects() {
+export default function ProjectsPage() {
   return (
-    <div className="grid gap-6 sm:grid-cols-2">
-      <Card className="rounded-2xl border border-border p-5 shadow-soft">
-        <h3 className="text-xl font-medium">Máquina de Cuentos</h3>
-        <p className="text-muted-foreground">Pipeline multi-agente para cuentos infantiles.</p>
-      </Card>
-      <Card className="rounded-2xl border border-border p-5 shadow-soft">
-        <h3 className="text-xl font-medium">AI-JonAbad Assistant</h3>
-        <p className="text-muted-foreground">Chat con RAG y guardarraíl sobre Jon Abad.</p>
-      </Card>
-    </div>
-  )
+    <main className="container mx-auto py-12">
+      <h1 className="text-3xl md:text-4xl font-semibold mb-8">Proyectos</h1>
+
+      <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((p) => (
+          <ProjectCard key={p.id} project={p} />
+        ))}
+      </section>
+    </main>
+  );
 }

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,41 @@
+// src/components/projects/ProjectCard.tsx
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import Image from "next/image";
+import Link from "next/link";
+import type { Project } from "@/data/projects";
+
+export function ProjectCard({ project }: { project: Project }) {
+  const { id, title, blurb, tags, cover, alt, links } = project;
+  return (
+    <Card className="overflow-hidden rounded-2xl hover:shadow-soft transition-shadow">
+      <div className="relative aspect-video">
+        <Image src={cover} alt={alt} fill className="object-cover" sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw" priority={false}/>
+      </div>
+      <CardContent className="p-5 space-y-3">
+        <h3 className="text-xl font-medium">{title}</h3>
+        <p className="text-sm text-muted-foreground">{blurb}</p>
+
+        <div className="flex flex-wrap gap-2">
+          {tags.map((t) => (
+            <Badge key={`${id}-${t}`} variant="secondary" className="rounded-2xl">
+              {t}
+            </Badge>
+          ))}
+        </div>
+
+        <nav className="flex gap-3 text-sm pt-1">
+          {links?.live && (
+            <Link className="underline underline-offset-4" href={links.live}>Ver</Link>
+          )}
+          {links?.case && (
+            <Link className="underline underline-offset-4" href={links.case}>Caso</Link>
+          )}
+          {links?.repo && (
+            <a className="underline underline-offset-4" href={links.repo} target="_blank" rel="noreferrer">Repo</a>
+          )}
+        </nav>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/projects/ProjectsPreview.tsx
+++ b/src/components/projects/ProjectsPreview.tsx
@@ -1,0 +1,20 @@
+// src/components/projects/ProjectsPreview.tsx
+import { projects } from "@/data/projects";
+import { ProjectCard } from "./ProjectCard";
+
+export function ProjectsPreview() {
+  const featured = projects.filter(p => p.featured).slice(0, 3);
+  if (featured.length === 0) return null;
+
+  return (
+    <section className="container mx-auto py-12 space-y-6">
+      <header>
+        <h2 className="text-2xl font-semibold">Proyectos destacados</h2>
+        <p className="text-sm text-muted-foreground">Una muestra rápida de mi trabajo reciente.</p>
+      </header>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {featured.map((p) => <ProjectCard key={p.id} project={p} />)}
+      </div>
+    </section>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,93 @@
+// src/data/projects.ts
+export type Project = {
+    id: string;
+    title: string;
+    blurb: string;
+    year: number;
+    tags: string[];
+    stack: string[];
+    cover: string;
+    alt: string;
+    links?: { live?: string; repo?: string; case?: string };
+    featured?: boolean;
+    highlights?: string[];
+  };
+  
+  export const projects: Project[] = [
+    {
+      id: "jon-abad-assistant",
+      title: "Jon Abad Assistant",
+      blurb:
+        "Asistente conversacional con RAG, guardarraíles y streaming en Edge, integrado en mi portfolio.",
+      year: 2025,
+      tags: ["RAG", "Streaming", "Guardarraíles"],
+      stack: ["Next.js (Edge)", "OpenAI SDK", "Supabase"],
+      cover: "/projects/jon-abad-assistant/cover.webp",
+      alt: "Interfaz del asistente con respuestas en streaming y citación de contexto",
+      links: {
+        live: "/assistant",
+        repo: "https://github.com/jonanderabad/ai-jonabad",
+        case: "/projects/jon-abad-assistant",
+      },
+      featured: true,
+      highlights: [
+        "P95 de respuesta ≈ 950 ms con streaming Edge.",
+        "RAG con embeddings (top-K=10) y KB de 176 entradas.",
+        "Rate limiting distribuido (Supabase): 429 + Retry-After y UX de bloqueo.",
+      ],
+    },
+    {
+      id: "maquina-de-cuentos",
+      title: "Máquina de Cuentos",
+      blurb:
+        "Ecosistema multi-agente para generar cuentos: guion por escenas y arte consistente con Flux/ComfyUI.",
+      year: 2025,
+      tags: ["Generativo", "Narrativa", "Multi-agente"],
+      stack: ["Flux Kontext", "ComfyUI", "PyTorch"],
+      cover: "/projects/maquina-de-cuentos/cover.webp",
+      alt: "Storyboard de cuento con prompts por escena y arte consistente",
+      links: { case: "/projects/maquina-de-cuentos" },
+      featured: true,
+      highlights: [
+        "Pipeline estructurado: texto → prompts por escena → imágenes con consistencia.",
+        "Control de semilla y LoRA para continuidad de estilo y personaje.",
+        "Operable localmente o con GPU externas; integración con Flux Playground.",
+      ],
+    },
+    {
+      id: "portfolio-inteligente",
+      title: "Portfolio Inteligente (ai.jonabad.es)",
+      blurb:
+        "Sitio y sistema base con SEO, OG dinámico y asistente integrado para mostrar trabajo real en producción.",
+      year: 2025,
+      tags: ["Web", "SEO", "RAG"],
+      stack: ["Next.js 15", "Tailwind + shadcn", "Vercel"],
+      cover: "/projects/portfolio-inteligente/cover.webp",
+      alt: "Homepage con hero animado y acceso al asistente",
+      links: {
+        live: "/",
+        repo: "https://github.com/jonanderabad/ai-jonabad",
+        case: "/projects/portfolio-inteligente",
+      },
+      featured: true,
+    },
+    {
+      id: "mcp-academy",
+      title: "MCP Academy / Mente Sintética",
+      blurb:
+        "Formación aplicada: fundamentos de MCP, creación de servidores y flujo real de despliegue.",
+      year: 2025,
+      tags: ["Formación", "MCP", "Agentes"],
+      stack: ["Claude Desktop", "MCP", "GitHub"],
+      cover: "/projects/mcp-academy/cover.webp",
+      alt: "Diapositivas y demo en vivo de un servidor MCP",
+      links: { live: "/academy", case: "/projects/mcp-academy" },
+      featured: false,
+      highlights: [
+        "Masterclass de iniciación: los alumnos crean su primer servidor MCP.",
+        "Recursos curados y guía paso a paso desde cero.",
+        "Próxima sesión: clientes y MCPs personalizados en producción.",
+      ],
+    },
+  ];
+  


### PR DESCRIPTION
Contexto
- Migramos "Proyectos" a una grid data-driven y añadimos sección de destacados en Home.

Cambios
- Nuevo: src/data/projects.ts (tipado Project + 4 proyectos iniciales).
- Nuevo: src/components/projects/ProjectCard.tsx (Card reutilizable con cover, chips y links).
- Nuevo: src/components/projects/ProjectsPreview.tsx (muestra 3 destacados).
- Refactor: src/app/projects/page.tsx ahora mapea 'projects' y usa <ProjectCard/>.
- Refactor: src/app/page.tsx añade <ProjectsPreview /> debajo del bloque intro.

Motivación
- Escalabilidad del contenido sin tocar JSX.
- Reutilización de UI (shadcn Card/Badge).
- Preparado para futuras páginas de detalle y filtros.

Validación
- Local OK: pnpm build / pnpm dev → /projects y Home renderizan correctamente.
- Accesibilidad: alt en imágenes, foco visible; jerarquía semántica.
- Responsive: 1 col (móvil), 2 col (sm), 3 col (lg).
- Links: live/case/repo funcionan (los vacíos no se muestran).

Impacto / Riesgo
- Solo UI y datos locales; sin cambios en API ni RAG. Riesgo bajo.

Siguientes pasos
- (Opcional) Filtros por tag/stack.
- (Opcional) Páginas de detalle /projects/[id].
