### PR TITLE
feat(projects): embed long-form case in detail + MDX config via @next/mdx

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,37 @@
+// next.config.ts
 import type { NextConfig } from "next";
+import createMDX from "@next/mdx";
+
+/**
+ * Envoltorio MDX: habilita soporte para archivos .md y .mdx en el App Router.
+ * Puedes añadir remark/rehype plugins en `options` si los necesitas.
+ */
+const withMDX = createMDX({
+  extension: /\.mdx?$/,
+  // options: {
+  //   remarkPlugins: [],
+  //   rehypePlugins: [],
+  // },
+});
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /**
+   * Next tratará también .md/.mdx como páginas.
+   * Ejemplo de ruta: src/app/projects/<id>/case/page.mdx
+   */
+  pageExtensions: ["ts", "tsx", "md", "mdx"],
+
+  experimental: {
+    /**
+     * Compilador MDX rápido (Rust). Seguro en Next 15.
+     * Si ya tienes otras flags experimentales, mantenlas aquí.
+     */
+    mdxRs: true,
+  },
+
+  // Aquí puedes seguir añadiendo más opciones si las necesitas:
+  // images: { remotePatterns: [...] },
+  // redirects: async () => [...],
 };
 
-export default nextConfig;
+export default withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@next/mdx": "^15.5.3",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^20.19.11",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@next/mdx':
+        specifier: ^15.5.3
+        version: 15.5.3(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.1.0))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.13)
@@ -460,8 +463,25 @@ packages:
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@next/env@15.5.2':
     resolution: {integrity: sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==}
+
+  '@next/mdx@15.5.3':
+    resolution: {integrity: sha512-tpD3sdWfAiqjqD1WXL4ZEpxswXdbeoTQjlgvDzbQOxDr37qaAo9bFkpMVb3P3pgAJAQ9Q6w1Yql6YtOsmgZrzg==}
+    peerDependencies:
+      '@mdx-js/loader': '>=0.15.0'
+      '@mdx-js/react': '>=0.15.0'
+    peerDependenciesMeta:
+      '@mdx-js/loader':
+        optional: true
+      '@mdx-js/react':
+        optional: true
 
   '@next/swc-darwin-arm64@15.5.2':
     resolution: {integrity: sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ==}
@@ -1004,6 +1024,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
@@ -1738,6 +1761,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2221,7 +2248,20 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.1.0)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.1.12
+      react: 19.1.0
+    optional: true
+
   '@next/env@15.5.2': {}
+
+  '@next/mdx@15.5.3(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.1.0))':
+    dependencies:
+      source-map: 0.7.6
+    optionalDependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.1.12)(react@19.1.0)
 
   '@next/swc-darwin-arm64@15.5.2':
     optional: true
@@ -2702,6 +2742,9 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/mdx@2.0.13':
+    optional: true
 
   '@types/node@20.19.11':
     dependencies:
@@ -3427,6 +3470,8 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
 
   stackback@0.0.2: {}
 

--- a/src/app/projects/[id]/cases.ts
+++ b/src/app/projects/[id]/cases.ts
@@ -1,0 +1,16 @@
+import type { ComponentType } from 'react';
+
+export async function loadCase(id: string): Promise<ComponentType<any> | null> {
+  switch (id) {
+    case 'jon-abad-assistant':
+      return (await import('../../../content/projects/jon-abad-assistant/case.mdx')).default;
+    case 'maquina-de-cuentos':
+      return (await import('../../../content/projects/maquina-de-cuentos/case.mdx')).default;
+    case 'portfolio-inteligente':
+      return (await import('../../../content/projects/portfolio-inteligente/case.mdx')).default;
+    case 'mcp-academy':
+      return (await import('../../../content/projects/mcp-academy/case.mdx')).default;
+    default:
+      return null;
+  }
+}

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { loadCase } from "./cases"; // <- loader que importa el MDX según el id
 
 type Params = { id: string };
 
@@ -37,9 +38,12 @@ export function generateMetadata({ params }: { params: Params }) {
   };
 }
 
-export default function ProjectDetail({ params }: { params: Params }) {
+export default async function ProjectDetail({ params }: { params: Params }) {
   const p = projects.find((x) => x.id === params.id);
   if (!p) notFound();
+
+  // Importa el componente MDX del caso si existe para este id.
+  const Case = await loadCase(params.id);
 
   return (
     <main className="container mx-auto max-w-4xl py-12 space-y-8">
@@ -57,14 +61,14 @@ export default function ProjectDetail({ params }: { params: Params }) {
         </div>
       </header>
 
-      {/* Si la imagen de portada aún no está subida, simplemente no se mostrará.
-         No rompe la página; cuando subas /public/projects/<id>/cover.webp aparecerá. */}
+      {/* Cover: mantiene la estética del detalle */}
       {p.cover && (
         <div className="relative aspect-video rounded-2xl overflow-hidden border">
           <Image src={p.cover} alt={p.alt} fill className="object-cover" />
         </div>
       )}
 
+      {/* Highlights tal y como los tenías */}
       {p.highlights?.length ? (
         <section className="space-y-2">
           <h2 className="text-xl font-medium">Highlights</h2>
@@ -109,17 +113,28 @@ export default function ProjectDetail({ params }: { params: Params }) {
                     Repo
                   </a>
                 )}
-                {/* Solo mostramos "Caso" si es distinto a esta misma ruta */}
-                {p.links.case &&
-                  p.links.case !== `/projects/${p.id}` && (
-                    <Link className="underline" href={p.links.case}>
-                      Caso
-                    </Link>
-                  )}
+                {/* El enlace “Caso” ahora suele apuntar a /projects/<id>#case */}
+                {p.links.case && p.links.case !== `/projects/${p.id}` && (
+                  <Link className="underline" href={p.links.case}>
+                    Caso
+                  </Link>
+                )}
               </div>
             )}
           </CardContent>
         </Card>
+      )}
+
+      {/* Sección de Caso embebida (MDX), mantiene la UI del detalle */}
+      {Case && (
+        <section
+          id="case"
+          className="mt-12 rounded-2xl border border-border bg-background p-8 md:p-12 shadow-soft"
+        >
+          <div className="prose prose-zinc dark:prose-invert max-w-none">
+            <Case />
+          </div>
+        </section>
       )}
     </main>
   );

--- a/src/content/projects/jon-abad-assistant/case.mdx
+++ b/src/content/projects/jon-abad-assistant/case.mdx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Caso: Jon Abad Assistant",
+  description: "Asistente en producción con RAG, streaming y guardarraíles."
+};
+
+# Caso: Jon Abad Assistant
+
+**Objetivo.** Llevar un asistente real a producción con latencia P95 sub-segundo, garantizando calidad de recuperación (RAG) y seguridad (guardarraíles).
+
+## Contexto
+- Streaming Edge → UI con control de cancelación.
+- RAG con embeddings (top-K=10) y KB curada.
+- Rate limit por IP con Supabase RPC (429 + Retry-After).
+
+## Enfoque
+1. Saneado de entradas y guardarraíl semántico.
+2. Construcción de contexto con re-ranking y citación.
+3. Medición continua: P95, recall@k, 4xx/5xx y satisfacción.
+
+## Resultados
+- P95 ≈ 950 ms en producción (Edge).
+- Cobertura RAG estable y trazable.
+- UX de bloqueo/contador para 429.
+
+## Stack
+Next.js (Edge), OpenAI SDK, Supabase (RPC), Tailwind/shadcn.

--- a/src/content/projects/maquina-de-cuentos/case.mdx
+++ b/src/content/projects/maquina-de-cuentos/case.mdx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Caso: Máquina de Cuentos",
+  description: "Pipeline multi-agente para narrativa y arte consistente con Flux/ComfyUI."
+};
+
+# Caso: Máquina de Cuentos
+
+**Objetivo.** Generar cuentos con guion por escenas y arte visual consistente.
+
+## Pipeline
+- Texto → prompts por escena → imágenes controladas.
+- Semillas fijas y LoRA para continuidad de estilo/personaje.
+- Operable local o con GPU externas; integración con Flux Playground.
+
+## Enfoque
+1. Diseño de estructura (capítulos → escenas → prompts).
+2. Control de variabilidad (semillas, CFG, LoRA).
+3. Curación iterativa de assets y revisión humana.
+
+## Resultados
+- Coherencia narrativa y visual por escena.
+- Reducción de re-renders por control de semilla.
+- Fácil exportado a storyboards.
+
+## Stack
+Flux Kontext, ComfyUI, PyTorch.

--- a/src/content/projects/mcp-academy/case.mdx
+++ b/src/content/projects/mcp-academy/case.mdx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Caso: MCP Academy / Mente Sintética",
+  description: "Formación práctica en MCP: servidores, clientes y despliegue."
+};
+
+# Caso: MCP Academy / Mente Sintética
+
+**Objetivo.** Capacitar en fundamentos de MCP con un flujo práctico de extremo a extremo.
+
+## Contenido
+- Introducción a MCP y ecosistema.
+- Creación del primer servidor MCP.
+- Flujo de despliegue y orquestación básica.
+
+## Enfoque
+1. Taller paso a paso con ejercicios.
+2. Recursos curados y repos de ejemplo.
+3. Evaluación por casos reales.
+
+## Resultados
+- Participantes con servidor MCP funcional.
+- Comprensión de clientes y extensiones.
+- Base para proyectos de agentes personalizados.
+
+## Stack
+Claude Desktop, MCP, GitHub.

--- a/src/content/projects/portfolio-inteligente/case.mdx
+++ b/src/content/projects/portfolio-inteligente/case.mdx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Caso: Portfolio Inteligente",
+  description: "Sitio base con SEO, OG dinámico y asistente integrado."
+};
+
+# Caso: Portfolio Inteligente (ai.jonabad.es)
+
+**Objetivo.** Mostrar trabajo real en producción, con SEO sólido y asistente integrado.
+
+## Capas clave
+- OpenGraph dinámico y sitemap/robots automáticos.
+- Asistente con streaming Edge y guardarraíles.
+- RAG semántico con embeddings.
+
+## Enfoque
+1. Base Next 15 + Tailwind/shadcn con diseño minimal.
+2. Rutas data-driven (About, Projects, Detalle).
+3. Flujo de entrega: branches pequeños → PR → Vercel Preview → Squash & merge.
+
+## Resultados
+- Tiempo de entrega corto por micro-tareas.
+- Contenido escalable (data sources).
+- Despliegues confiables con verificación en Preview.
+
+## Stack
+Next.js 15, Tailwind + shadcn, Vercel.

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,93 +1,92 @@
 // src/data/projects.ts
 export type Project = {
-    id: string;
-    title: string;
-    blurb: string;
-    year: number;
-    tags: string[];
-    stack: string[];
-    cover: string;
-    alt: string;
-    links?: { live?: string; repo?: string; case?: string };
-    featured?: boolean;
-    highlights?: string[];
-  };
-  
-  export const projects: Project[] = [
-    {
-      id: "jon-abad-assistant",
-      title: "Jon Abad Assistant",
-      blurb:
-        "Asistente conversacional con RAG, guardarraíles y streaming en Edge, integrado en mi portfolio.",
-      year: 2025,
-      tags: ["RAG", "Streaming", "Guardarraíles"],
-      stack: ["Next.js (Edge)", "OpenAI SDK", "Supabase"],
-      cover: "/projects/jon-abad-assistant/cover.webp",
-      alt: "Interfaz del asistente con respuestas en streaming y citación de contexto",
-      links: {
-        live: "/assistant",
-        repo: "https://github.com/jonanderabad/ai-jonabad",
-        case: "/projects/jon-abad-assistant",
-      },
-      featured: true,
-      highlights: [
-        "P95 de respuesta ≈ 950 ms con streaming Edge.",
-        "RAG con embeddings (top-K=10) y KB de 176 entradas.",
-        "Rate limiting distribuido (Supabase): 429 + Retry-After y UX de bloqueo.",
-      ],
+  id: string;
+  title: string;
+  blurb: string;
+  year: number;
+  tags: string[];
+  stack: string[];
+  cover: string;
+  alt: string;
+  links?: { live?: string; repo?: string; case?: string };
+  featured?: boolean;
+  highlights?: string[];
+};
+
+export const projects: Project[] = [
+  {
+    id: "jon-abad-assistant",
+    title: "Jon Abad Assistant",
+    blurb:
+      "Asistente conversacional con RAG, guardarraíles y streaming en Edge, integrado en mi portfolio.",
+    year: 2025,
+    tags: ["RAG", "Streaming", "Guardarraíles"],
+    stack: ["Next.js (Edge)", "OpenAI SDK", "Supabase"],
+    cover: "/projects/jon-abad-assistant/cover.webp",
+    alt: "Interfaz del asistente con respuestas en streaming y citación de contexto",
+    links: {
+      live: "/assistant",
+      repo: "https://github.com/jonanderabad/ai-jonabad",
+      case: "/projects/jon-abad-assistant#case",
     },
-    {
-      id: "maquina-de-cuentos",
-      title: "Máquina de Cuentos",
-      blurb:
-        "Ecosistema multi-agente para generar cuentos: guion por escenas y arte consistente con Flux/ComfyUI.",
-      year: 2025,
-      tags: ["Generativo", "Narrativa", "Multi-agente"],
-      stack: ["Flux Kontext", "ComfyUI", "PyTorch"],
-      cover: "/projects/maquina-de-cuentos/cover.webp",
-      alt: "Storyboard de cuento con prompts por escena y arte consistente",
-      links: { case: "/projects/maquina-de-cuentos" },
-      featured: true,
-      highlights: [
-        "Pipeline estructurado: texto → prompts por escena → imágenes con consistencia.",
-        "Control de semilla y LoRA para continuidad de estilo y personaje.",
-        "Operable localmente o con GPU externas; integración con Flux Playground.",
-      ],
+    featured: true,
+    highlights: [
+      "P95 de respuesta ≈ 950 ms con streaming Edge.",
+      "RAG con embeddings (top-K=10) y KB de 176 entradas.",
+      "Rate limiting distribuido (Supabase): 429 + Retry-After y UX de bloqueo.",
+    ],
+  },
+  {
+    id: "maquina-de-cuentos",
+    title: "Máquina de Cuentos",
+    blurb:
+      "Ecosistema multi-agente para generar cuentos: guion por escenas y arte consistente con Flux/ComfyUI.",
+    year: 2025,
+    tags: ["Generativo", "Narrativa", "Multi-agente"],
+    stack: ["Flux Kontext", "ComfyUI", "PyTorch"],
+    cover: "/projects/maquina-de-cuentos/cover.webp",
+    alt: "Storyboard de cuento con prompts por escena y arte consistente",
+    links: { case: "/projects/maquina-de-cuentos#case" },
+    featured: true,
+    highlights: [
+      "Pipeline estructurado: texto → prompts por escena → imágenes con consistencia.",
+      "Control de semilla y LoRA para continuidad de estilo y personaje.",
+      "Operable localmente o con GPU externas; integración con Flux Playground.",
+    ],
+  },
+  {
+    id: "portfolio-inteligente",
+    title: "Portfolio Inteligente (ai.jonabad.es)",
+    blurb:
+      "Sitio y sistema base con SEO, OG dinámico y asistente integrado para mostrar trabajo real en producción.",
+    year: 2025,
+    tags: ["Web", "SEO", "RAG"],
+    stack: ["Next.js 15", "Tailwind + shadcn", "Vercel"],
+    cover: "/projects/portfolio-inteligente/cover.webp",
+    alt: "Homepage con hero animado y acceso al asistente",
+    links: {
+      live: "/",
+      repo: "https://github.com/jonanderabad/ai-jonabad",
+      case: "/projects/portfolio-inteligente#case",
     },
-    {
-      id: "portfolio-inteligente",
-      title: "Portfolio Inteligente (ai.jonabad.es)",
-      blurb:
-        "Sitio y sistema base con SEO, OG dinámico y asistente integrado para mostrar trabajo real en producción.",
-      year: 2025,
-      tags: ["Web", "SEO", "RAG"],
-      stack: ["Next.js 15", "Tailwind + shadcn", "Vercel"],
-      cover: "/projects/portfolio-inteligente/cover.webp",
-      alt: "Homepage con hero animado y acceso al asistente",
-      links: {
-        live: "/",
-        repo: "https://github.com/jonanderabad/ai-jonabad",
-        case: "/projects/portfolio-inteligente",
-      },
-      featured: true,
-    },
-    {
-      id: "mcp-academy",
-      title: "MCP Academy / Mente Sintética",
-      blurb:
-        "Formación aplicada: fundamentos de MCP, creación de servidores y flujo real de despliegue.",
-      year: 2025,
-      tags: ["Formación", "MCP", "Agentes"],
-      stack: ["Claude Desktop", "MCP", "GitHub"],
-      cover: "/projects/mcp-academy/cover.webp",
-      alt: "Diapositivas y demo en vivo de un servidor MCP",
-      links: { live: "/academy", case: "/projects/mcp-academy" },
-      featured: false,
-      highlights: [
-        "Masterclass de iniciación: los alumnos crean su primer servidor MCP.",
-        "Recursos curados y guía paso a paso desde cero.",
-        "Próxima sesión: clientes y MCPs personalizados en producción.",
-      ],
-    },
-  ];
-  
+    featured: true,
+  },
+  {
+    id: "mcp-academy",
+    title: "MCP Academy / Mente Sintética",
+    blurb:
+      "Formación aplicada: fundamentos de MCP, creación de servidores y flujo real de despliegue.",
+    year: 2025,
+    tags: ["Formación", "MCP", "Agentes"],
+    stack: ["Claude Desktop", "MCP", "GitHub"],
+    cover: "/projects/mcp-academy/cover.webp",
+    alt: "Diapositivas y demo en vivo de un servidor MCP",
+    links: { live: "/academy", case: "/projects/mcp-academy#case" },
+    featured: false,
+    highlights: [
+      "Masterclass de iniciación: los alumnos crean su primer servidor MCP.",
+      "Recursos curados y guía paso a paso desde cero.",
+      "Próxima sesión: clientes y MCPs personalizados en producción.",
+    ],
+  },
+];

--- a/src/mdx.d.ts
+++ b/src/mdx.d.ts
@@ -1,0 +1,5 @@
+declare module '*.mdx' {
+    const MDXComponent: (props: any) => JSX.Element;
+    export default MDXComponent;
+  }
+  


### PR DESCRIPTION
### Qué incluye
- **Detalle de proyecto**: renderiza el **caso largo (MDX) embebido** bajo el hero/cover, manteniendo la estética (badges, highlights, stack, links).
- **Integración MDX**: configuración con `@next/mdx`, `pageExtensions` (`ts`, `tsx`, `md`, `mdx`) y `experimental.mdxRs`.
- **Contenido**: casos movidos a `src/content/projects/<id>/case.mdx` para evitar rutas públicas `/projects/<id>/case`.
- **Enlaces**: `links.case` ahora apuntan a `#case` (`/projects/<id>#case`).

### Motivación
Recuperar la **estética original** del detalle y añadir el **caso extendido** sin perder el contexto visual (cover + bullets + UI). Evitamos páginas planas `/case` y consolidamos todo en una misma vista.

### Cómo validar
1. Abrir **Preview** de Vercel.
2. Navegar a `/projects/jon-abad-assistant` (y al resto de ids).
3. Verificar:
   - Hero + **cover** + **badges** + **highlights** visibles.
   - Botón **“Caso”** → navega a `/projects/<id>#case` y aparece el contenido **MDX** con estilos `.prose`.
   - La ruta `/projects/<id>/case` retorna **404**.
4. Ejecutar local:
   ```bash
   pnpm build && pnpm start
