### PR TITLE
feat(ui): reemplazar conversation starters por opciones alineadas con la KB (Portfolio, Proyectos, Flujo RAG)

### DIFF
--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -9,9 +9,9 @@ type ChatMessage = { role: Role; content: string };
 
 const STORAGE_KEY = "ms_chat_history_v1";
 const SUGGESTIONS = [
-  "¿Qué puedes hacer por mí?",
-  "Explícame el proyecto en 2 frases.",
-  "Quiero una demo de capacidades.",
+  "Portfolio de Jon Abad.",
+  "Proyectos destacados.",
+  "Flujo RAG del asistente.",
 ];
 
 export default function ChatWidget() {


### PR DESCRIPTION
Este PR sustituye los tres *conversation starters* del `ChatWidget` por opciones diseñadas para funcionar siempre con la base de conocimiento (KB) y el RAG del asistente.

**Antes:** los starters no mapeaban bien a la KB y a veces no devolvían respuesta útil.  
**Ahora:**  
1) **Portfolio de Jon Abad**  
2) **Proyectos destacados**  
3) **Flujo RAG del asistente**

Se mantiene el formato simple (array de strings), por lo que el cambio es mínimo y de bajo riesgo.

## Alcance
- Archivo modificado: `src/components/ChatWidget.tsx`
- Cambio: actualización de la constante `SUGGESTIONS` (3 strings nuevos)

## Motivación
Alinear los starters con el contenido real de la KB para garantizar respuestas consistentes y on-topic, mejorando la experiencia inicial del usuario en `/assistant`.

## Cómo probar (QA manual)
1. Abrir el **Preview de Vercel** y navegar a `/assistant`.
2. Verificar que aparecen exactamente **3 botones** con estos labels:
   - Portfolio de Jon Abad
   - Proyectos destacados
   - Flujo RAG del asistente
3. Hacer clic en cada botón y confirmar:
   - Las respuestas se basan **exclusivamente** en la KB.
   - No aparecen mensajes de fuera de ámbito.
   - La respuesta llega en **streaming** como de costumbre.

## Criterios de aceptación
- [x] Los 3 botones se renderizan con los labels indicados.
- [x] Cada starter produce respuesta on-topic con la KB.
- [x] Sin regresiones visuales en móvil/escritorio (layout estable).

## Riesgos / Consideraciones
- **Bajo**: cambio localizado (3 cadenas).  
- En caso de rollback, revertir el commit correspondiente.

## Notas de despliegue
- No requiere migraciones ni cambios de entorno.
- Validado en Preview de Vercel.
